### PR TITLE
make the library compatible with Spark 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ metastore_db/
 .scala_dependencies
 .worksheet
 /bin
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ metastore_db/
 .scala_dependencies
 .worksheet
 /bin
+
+# IntelliJ IDEA
 .idea

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ scalaVersion := "2.10.6"
 
 spName := "IGNF/spark-iqmulus"
 
-sparkVersion := "1.5.2"
+// sparkVersion := "1.5.2"
+sparkVersion := "1.6.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ scalaVersion := "2.10.6"
 
 spName := "IGNF/spark-iqmulus"
 
-// sparkVersion := "1.5.2"
 sparkVersion := "1.6.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")

--- a/src/main/scala/fr/ign/spark/iqmulus/ExtraStrategies.scala
+++ b/src/main/scala/fr/ign/spark/iqmulus/ExtraStrategies.scala
@@ -26,7 +26,10 @@ import org.apache.spark.sql.catalyst.expressions.{ Alias, IntegerLiteral }
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.catalyst.expressions.{ Min, Max, Count, Expression, NamedExpression }
+// import org.apache.spark.sql.catalyst.expressions.{ Min, Max, Count, Expression, NamedExpression }
+import org.apache.spark.sql.catalyst.expressions.aggregate.{ Min, Max, Count } // Kun: make compatible with 1.6.0
+import org.apache.spark.sql.catalyst.expressions.{ Expression, NamedExpression } // Kun: make compatible with 1.6.0
+
 import scala.reflect.{ classTag, ClassTag }
 
 // optimized counts for PLY and LAS relations
@@ -34,7 +37,8 @@ case class CountPlan(n: Long, sections: Array[BinarySection], name: String) exte
   println("CountPlan optimization !")
   def count = n * sections.map(_.count).sum
 
-  override def executeCollect(): Array[Row] = Array(Row(count))
+  //override def executeCollect(): Array[Row] = Array(Row(count))
+  override def executeCollect(): Array[InternalRow] = Array(InternalRow(count)) // Kun: make compatibale with 1.6.0
 
   def doExecute() = sqlContext.sparkContext.parallelize(Seq(InternalRow(count)), 1)
 
@@ -61,7 +65,9 @@ case class AggregatePlan(aggregateExpressions: Seq[NamedExpression], headers: Ar
     case Count(IntegerLiteral(n)) => headers.map(_.pdr_nb).sum * n
   }
 
-  override def executeCollect(): Array[Row] = Array(Row.fromSeq(aggregateExpressions.map(get _)))
+  // override def executeCollect(): Array[Row] = Array(Row.fromSeq(aggregateExpressions.map(get _)))
+  // Kun: make compatible with 1.6.0
+  override def executeCollect(): Array[InternalRow] = Array(InternalRow.fromSeq(aggregateExpressions.map(get _)))
 
   def doExecute() = sqlContext.sparkContext.parallelize(Seq(
     InternalRow.fromSeq(aggregateExpressions.map(get _))

--- a/src/main/scala/fr/ign/spark/iqmulus/ExtraStrategies.scala
+++ b/src/main/scala/fr/ign/spark/iqmulus/ExtraStrategies.scala
@@ -26,9 +26,8 @@ import org.apache.spark.sql.catalyst.expressions.{ Alias, IntegerLiteral }
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-// import org.apache.spark.sql.catalyst.expressions.{ Min, Max, Count, Expression, NamedExpression }
-import org.apache.spark.sql.catalyst.expressions.aggregate.{ Min, Max, Count } // Kun: make compatible with 1.6.0
-import org.apache.spark.sql.catalyst.expressions.{ Expression, NamedExpression } // Kun: make compatible with 1.6.0
+import org.apache.spark.sql.catalyst.expressions.aggregate.{ Min, Max, Count }
+import org.apache.spark.sql.catalyst.expressions.{ Expression, NamedExpression }
 
 import scala.reflect.{ classTag, ClassTag }
 
@@ -37,8 +36,7 @@ case class CountPlan(n: Long, sections: Array[BinarySection], name: String) exte
   println("CountPlan optimization !")
   def count = n * sections.map(_.count).sum
 
-  //override def executeCollect(): Array[Row] = Array(Row(count))
-  override def executeCollect(): Array[InternalRow] = Array(InternalRow(count)) // Kun: make compatibale with 1.6.0
+  override def executeCollect(): Array[InternalRow] = Array(InternalRow(count))
 
   def doExecute() = sqlContext.sparkContext.parallelize(Seq(InternalRow(count)), 1)
 
@@ -65,8 +63,6 @@ case class AggregatePlan(aggregateExpressions: Seq[NamedExpression], headers: Ar
     case Count(IntegerLiteral(n)) => headers.map(_.pdr_nb).sum * n
   }
 
-  // override def executeCollect(): Array[Row] = Array(Row.fromSeq(aggregateExpressions.map(get _)))
-  // Kun: make compatible with 1.6.0
   override def executeCollect(): Array[InternalRow] = Array(InternalRow.fromSeq(aggregateExpressions.map(get _)))
 
   def doExecute() = sqlContext.sparkContext.parallelize(Seq(


### PR DESCRIPTION
Hi,

In Spark 1.6.0, the SparkPlan class has some changes regarding its member functions. The fix in ExtraStrategies.scala is done to make the library compatible using Spark 1.6.0. 

Cheers,
Kun
